### PR TITLE
Feature/install poetry when init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ check: format lint
 
 init:
 	pip install -U pip
+
+	# install poetry
+	curl -sSL https://install.python-poetry.org | python3 -
+	export PATH=$(HOME)/.local/bin:$(PATH)
+
 	poetry install
 	python -m pre_commit run
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ init:
 	export PATH=$(HOME)/.local/bin:$(PATH)
 
 	poetry install
+	python -m pre_commit install -f
+
 	python -m pre_commit run
 
 format:

--- a/main..py
+++ b/main..py
@@ -1,0 +1,19 @@
+import click
+
+
+@click.group()
+def main():
+    """Run group of CLI."""
+
+
+@click.command()
+@click.option("--dummy", type=str, default="", help="Dummy argument.")
+def run(dummy: str) -> None:
+    """Run."""
+    print(dummy)
+
+
+if __name__ == "__main__":
+    main.add_command(run)
+
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,1 +1,0 @@
-def teset_fun(): print("fi")

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,1 @@
+def teset_fun(): print("fi")


### PR DESCRIPTION
## As-is
* install poetry in another way
* no main.py

## To-be
* install poetry when running `make init`
* Add sample `main.py` 
