### PR TITLE
Resolve `make init` bug - install poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ init:
 
 	# install poetry
 	curl -sSL https://install.python-poetry.org | python3 -
-	export PATH=$(HOME)/.local/bin:$(PATH)
+	export PATH=$HOME/.local/bin:$PATH
 
 	poetry install
 	python -m pre_commit install -f


### PR DESCRIPTION
## As-is
`make init` makes an error

## To-be
We can install poetry normally via `make init`
